### PR TITLE
Cuda CI windows

### DIFF
--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -81,7 +81,12 @@ jobs:
           path: |
             C:/Miniconda/envs/test/conda-bld/*/work/python/build/temp.win-amd64-3.6/Release/CMakeFiles/CMakeError.log
             C:/Miniconda/envs/test/conda-bld/*/work/python/build/temp.win-amd64-3.6/Release/CMakeFiles/CMakeOutput.log
-            C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.2/bin/nvcc.exe
+
+      - name: Upload other CMake error log
+        uses: actions/upload-artifact@v2
+        with:
+          name: Other_CmakeError.log
+          path: |
             **/python/build/**/Release/CMakeFiles/CMakeError.log
             **/python/build/**/Release/CMakeFiles/CMakeOutput.log
 

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -70,13 +70,9 @@ jobs:
         if: ${{ matrix.os_base == 'windows' }}
         run: |
           Set-Location -Path .\dist_tools\conda
-
+          [System.Environment]::SetEnvironmentVariable('VSCMD_DEBUG','3',[System.EnvironmentVariableTarget]::User)
           conda-build -c conda-forge spline
           conda-build -c conda-forge spline --output > $Env:FILENAMES
-
-      - name: List dir
-        run: |
-          Get-ChildItem -Recurse "C:/Miniconda/envs/test/conda-bld/"
 
       - name: Upload CMake error log
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -57,8 +57,6 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.1
         with:
           cuda: '11.2.2'
-          method: 'network'
-          sub-packages: '["nvcc"]'
 
       - name: Build SplinePSF (UNIX)
         if: ${{ matrix.os_base == 'ubuntu' || matrix.os_base == 'macos'}}

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -52,6 +52,14 @@ jobs:
         if: ${{ matrix.os_base == 'macos'}}
         run: sudo xcode-select --switch /Applications/Xcode_11.5.app/Contents/Developer
 
+      - name: Install CUDA (Ubuntu/Windows)
+        if: ${{ matrix.os_base == 'ubuntu' || matrix.os_base == 'windows'}}
+        uses: Jimver/cuda-toolkit@v0.2.1
+        with:
+          cuda: '11.2.2'
+          method: 'network'
+          subPackages: '["nvcc"]'
+
       - name: Build SplinePSF (UNIX)
         if: ${{ matrix.os_base == 'ubuntu' || matrix.os_base == 'macos'}}
         run: |

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: CMakeError.log
-          path: '**/CMakeError.log'
+          path: '**/python/build/**/Release/CMakeFiles/CMakeError.log'
 
       - name: Change anaconda label on release
         if: github.event.release

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -65,11 +65,6 @@ jobs:
 
           conda-build -c conda-forge spline
           conda-build -c conda-forge spline --output > $FILENAMES
-
-      - name: Print path (Windows)
-        if: ${{ matrix.os_base == 'windows' }}
-        run: |
-          echo $env:PATH
       
       - name: Build SplinePSF (Windows)
         if: ${{ matrix.os_base == 'windows' }}
@@ -78,6 +73,12 @@ jobs:
 
           conda-build -c conda-forge spline
           conda-build -c conda-forge spline --output > $Env:FILENAMES
+
+      - name: Upload CMake error log
+        uses: actions/upload-artifact@v2
+        with:
+          name: CMakeError.log
+          path: python/build/**/Release/CMakeFiles/CMakeError.log
 
       - name: Change anaconda label on release
         if: github.event.release

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -74,6 +74,10 @@ jobs:
           conda-build -c conda-forge spline
           conda-build -c conda-forge spline --output > $Env:FILENAMES
 
+      - name: List dir
+        run: |
+          Get-ChildItem -Recurse "C:/Miniconda/envs/test/conda-bld/"
+
       - name: Upload CMake error log
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: CMakeError.log
-          path: ${{ github.workspace }}/python/build/**/Release/CMakeFiles/CMakeError.log
+          path: '**/CMakeError.log'
 
       - name: Change anaconda label on release
         if: github.event.release

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           cuda: '11.2.2'
           method: 'network'
-          subPackages: '["nvcc"]'
+          sub-packages: '["nvcc"]'
 
       - name: Build SplinePSF (UNIX)
         if: ${{ matrix.os_base == 'ubuntu' || matrix.os_base == 'macos'}}

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -70,7 +70,7 @@ jobs:
         if: ${{ matrix.os_base == 'windows' }}
         run: |
           Set-Location -Path .\dist_tools\conda
-          [System.Environment]::SetEnvironmentVariable('VSCMD_DEBUG','3',[System.EnvironmentVariableTarget]::User)
+          $env:VSCMD_DEBUG=3
           conda-build -c conda-forge spline
           conda-build -c conda-forge spline --output > $Env:FILENAMES
 

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -79,8 +79,8 @@ jobs:
         with:
           name: CMakeError.log
           path: |
-            C:/Miniconda/envs/test/conda-bld/*/work/python/build/temp.win-amd64-3.6/Release/CMakeFiles/CMakeError.log
-            C:/Miniconda/envs/test/conda-bld/*/work/python/build/temp.win-amd64-3.6/Release/CMakeFiles/CMakeOutput.log
+            C:/Miniconda/envs/test/conda-bld/*/work/python/build/temp.win-amd64-3.*/Release/CMakeFiles/CMakeError.log
+            C:/Miniconda/envs/test/conda-bld/*/work/python/build/temp.win-amd64-3.*/Release/CMakeFiles/CMakeOutput.log
 
       - name: Upload other CMake error log
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -78,7 +78,12 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: CMakeError.log
-          path: '**/python/build/**/Release/CMakeFiles/CMakeError.log'
+          path: |
+            C:/Miniconda/envs/test/conda-bld/*/work/python/build/temp.win-amd64-3.6/Release/CMakeFiles/CMakeError.log
+            C:/Miniconda/envs/test/conda-bld/*/work/python/build/temp.win-amd64-3.6/Release/CMakeFiles/CMakeOutput.log
+            C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.2/bin/nvcc.exe
+            **/python/build/**/Release/CMakeFiles/CMakeError.log
+            **/python/build/**/Release/CMakeFiles/CMakeOutput.log
 
       - name: Change anaconda label on release
         if: github.event.release

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -66,6 +66,11 @@ jobs:
           conda-build -c conda-forge spline
           conda-build -c conda-forge spline --output > $FILENAMES
 
+      - name: Print path (Windows)
+        if: ${{ matrix.os_base == 'windows' }}
+        run: |
+          echo $env:PATH
+      
       - name: Build SplinePSF (Windows)
         if: ${{ matrix.os_base == 'windows' }}
         run: |

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: CMakeError.log
-          path: python/build/**/Release/CMakeFiles/CMakeError.log
+          path: ${{ github.workspace }}/python/build/**/Release/CMakeFiles/CMakeError.log
 
       - name: Change anaconda label on release
         if: github.event.release

--- a/.github/workflows/build_upload_test.yaml
+++ b/.github/workflows/build_upload_test.yaml
@@ -52,8 +52,8 @@ jobs:
         if: ${{ matrix.os_base == 'macos'}}
         run: sudo xcode-select --switch /Applications/Xcode_11.5.app/Contents/Developer
 
-      - name: Install CUDA (Ubuntu/Windows)
-        if: ${{ matrix.os_base == 'ubuntu' || matrix.os_base == 'windows'}}
+      - name: Install CUDA (Windows)
+        if: ${{matrix.os_base == 'windows'}}
         uses: Jimver/cuda-toolkit@v0.2.1
         with:
           cuda: '11.2.2'

--- a/cpp_cuda_c/CMakeLists.txt
+++ b/cpp_cuda_c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 #cmake_policy(SET CMP0094 NEW)
 
 project(SplinePSF LANGUAGES CXX C)
@@ -8,7 +8,7 @@ check_language(CUDA)
 
 find_package(Python COMPONENTS Interpreter Development)
 find_package(pybind11 REQUIRED)
-find_package(CUDA)
+find_package(CUDAToolkit)
 
 if(CMAKE_CUDA_COMPILER AND NOT CUDA_DISABLED)  # the latter is a user definable variable
    enable_language(CUDA)

--- a/cpp_cuda_c/CMakeLists.txt
+++ b/cpp_cuda_c/CMakeLists.txt
@@ -34,8 +34,8 @@ if(CMAKE_CUDA_COMPILER AND NOT CUDA_DISABLED)
    target_compile_features(spline_psf_cu_impl PUBLIC cxx_std_11)
    set_target_properties(spline_psf_cu_impl PROPERTIES CUDA_SEPARABLE_COMPILATION ON POSITION_INDEPENDENT_CODE ON)
 
-   link_directories(/usr/local/cuda/lib64)
-   include_directories("${CUDA_INCLUDE_DIRS}")
+   # link_directories(/usr/local/cuda/lib64)
+   # include_directories("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}")
 
    pybind11_add_module(spline src/pybind_spline.cpp)
    target_link_libraries(spline PRIVATE spline_psf_cu_impl spline_psf_cpu_impl)

--- a/cpp_cuda_c/CMakeLists.txt
+++ b/cpp_cuda_c/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Python COMPONENTS Interpreter Development)
 find_package(pybind11 REQUIRED)
 find_package(CUDAToolkit)
 
-if(CMAKE_CUDA_COMPILER AND NOT CUDA_DISABLED)  # the latter is a user definable variable
+if(CUDAToolkit_FOUND AND NOT CUDA_DISABLED)  # the latter is a user definable variable
    enable_language(CUDA)
    add_compile_definitions(CUDA_ENABLED)
 
@@ -28,7 +28,7 @@ target_include_directories(spline_psf_cpu_impl PUBLIC include)
 target_compile_features(spline_psf_cpu_impl PUBLIC c_std_99)
 set_property(TARGET spline_psf_cpu_impl PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-if(CMAKE_CUDA_COMPILER AND NOT CUDA_DISABLED)
+if(CUDAToolkit_FOUND AND NOT CUDA_DISABLED)
    add_library(spline_psf_cu_impl STATIC src/spline_psf_gpu.cu)
    target_include_directories(spline_psf_cu_impl PUBLIC include)
    target_compile_features(spline_psf_cu_impl PUBLIC cxx_std_11)

--- a/cpp_cuda_c/src/spline_psf_gpu.cu
+++ b/cpp_cuda_c/src/spline_psf_gpu.cu
@@ -522,17 +522,17 @@ auto kernel_roi(spline *sp, float *rois, const int npx, const int npy, const flo
     float phot = phot_[r];
 
     /* Compute delta. Will be the same for all following px */
-    x0 = (int)floor(xc);
+    x0 = (int)floorf(xc);
     x_delta = xc - x0;
 
-    y0 = (int)floor(yc);
+    y0 = (int)floorf(yc);
     y_delta = yc - y0;
 
-    z0 = (int)floor(zc);
+    z0 = (int)floorf(zc);
     z_delta = zc - z0;
 
     int n_threads = min(1024, npx * npy);  // max number of threads per block
-    int n_blocks = ceil(static_cast<float>(npx * npy) / static_cast<float>(n_threads));
+    int n_blocks = ceilf(static_cast<float>(npx * npy) / static_cast<float>(n_threads));
 
     fAt3Dj<<<n_blocks, n_threads>>>(sp, rois, r, npx, npy, x0, y0, z0, phot, x_delta, y_delta, z_delta);
 
@@ -555,17 +555,17 @@ auto kernel_derivative_roi(spline *sp, float *rois, float *drv_rois, const int n
     float bg = bg_[r];
 
     /* Compute delta. Will be the same for all following px */
-    x0 = (int)floor(xc);
+    x0 = (int)floorf(xc);
     x_delta = xc - x0;
 
-    y0 = (int)floor(yc);
+    y0 = (int)floorf(yc);
     y_delta = yc - y0;
 
-    z0 = (int)floor(zc);
+    z0 = (int)floorf(zc);
     z_delta = zc - z0;
 
     int n_threads = min(1024, npx * npy);  // max number of threads per block
-    int n_blocks = ceil(static_cast<float>(npx * npy) / static_cast<float>(n_threads));
+    int n_blocks = ceilf(static_cast<float>(npx * npy) / static_cast<float>(n_threads));
 
     kernel_derivative<<<n_blocks, n_threads>>>(sp, rois, drv_rois, r, npx, npy, x0, y0, z0, phot, bg, x_delta, y_delta, z_delta, add_bg);
 

--- a/dist_tools/conda/conda_build_config.yaml
+++ b/dist_tools/conda/conda_build_config.yaml
@@ -2,11 +2,11 @@
 c_compiler:
     - clang                            # [osx]
     - gcc                              # [linux]
-    - vs2017                           # [win]
+    - vs2019                           # [win]
 cxx_compiler:
     - clangxx                          # [osx]
     - gxx                              # [linux]
-    - vs2017                           # [win]
+    - vs2019                           # [win]
 target_platform:
     - osx-64                           # [osx]
     - linux-64                         # [linux]

--- a/dist_tools/conda/spline/meta.yaml
+++ b/dist_tools/conda/spline/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - python
-    - cmake =3.15
+    - cmake =3.17
     - ninja
     - setuptools
 

--- a/python/environment.yml
+++ b/python/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - bump2version
   - python=3.7
-  - cmake=3.15
+  - cmake=3.17
   - ninja
   - setuptools
   - numpy


### PR DESCRIPTION
I looked at the CI and it seems you use a bit outdated version of getting cuda in your `cmakelists.txt`

I now use `find_package(CUDAToolkit)` which was introduced in CMake 3.17, so I updated those to 3.17 as well, not sure if that impacts other stuff though. But the CI seems to run fine on my fork.

I also changed floor to floorf and ceil to ceilf, see: https://devtalk.blender.org/t/cuda-compile-error-windows-10/17886/2